### PR TITLE
Major Changes

### DIFF
--- a/Autounattend.xml
+++ b/Autounattend.xml
@@ -1,167 +1,155 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
-    <servicing/>
-    <settings pass="windowsPE">
-        <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-            <DiskConfiguration>
-                <Disk wcm:action="add">
-                    <CreatePartitions>
-                        <CreatePartition wcm:action="add">
-                            <Order>1</Order>
-                            <Type>Primary</Type>
-                            <Extend>true</Extend>
-                        </CreatePartition>
-                    </CreatePartitions>
-                    <ModifyPartitions>
-                        <ModifyPartition wcm:action="add">
-                            <Extend>false</Extend>
-                            <Format>NTFS</Format>
-                            <Letter>C</Letter>
-                            <Order>1</Order>
-                            <PartitionID>1</PartitionID>
-                            <Label>Windows 81</Label>
-                        </ModifyPartition>
-                    </ModifyPartitions>
-                    <DiskID>0</DiskID>
-                    <WillWipeDisk>true</WillWipeDisk>
-                </Disk>
-                <WillShowUI>OnError</WillShowUI>
-            </DiskConfiguration>
-            <UserData>
-                <AcceptEula>true</AcceptEula>
-                <FullName>Vagrant Administrator</FullName>
-                <Organization>Vagrant Inc.</Organization>
+        <servicing/>
+        <settings pass="windowsPE">
+            <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+                <DiskConfiguration>
+                    <Disk wcm:action="add">
+                        <CreatePartitions>
+                            <CreatePartition wcm:action="add">
+                                <Order>1</Order>
+                                <Type>Primary</Type>
+                                <Extend>true</Extend>
+                            </CreatePartition>
+                        </CreatePartitions>
+                        <ModifyPartitions>
+                            <ModifyPartition wcm:action="add">
+                                <Extend>false</Extend>
+                                <Format>NTFS</Format>
+                                <Letter>C</Letter>
+                                <Order>1</Order>
+                                <PartitionID>1</PartitionID>
+                                <Label>Windows 81</Label>
+                            </ModifyPartition>
+                        </ModifyPartitions>
+                        <DiskID>0</DiskID>
+                        <WillWipeDisk>true</WillWipeDisk>
+                    </Disk>
+                    <WillShowUI>OnError</WillShowUI>
+                </DiskConfiguration>
+                <UserData>
+                    <AcceptEula>true</AcceptEula>
+                    <FullName>Vagrant Administrator</FullName>
+                    <Organization>Vagrant Inc.</Organization>
 
-                <!--
-                    NOTE: If you are re-configuring this for use of a retail key 
-                    and using a retail ISO, you need to adjust the <ProductKey> block
-                    below to look like this:
+                    <!--
+                        NOTE: If you are re-configuring this for use of a retail key 
+                        and using a retail ISO, you need to adjust the <ProductKey> block
+                        below to look like this:
+                        <ProductKey>
+                            <Key>33PXH-7Y6KF-2VJC9-XBBR8-HVTHH</Key>
+                            <WillShowUI>Never</WillShowUI>
+                        </ProductKey>
+                        Notice the addition of the `<Key>` element.
+                    -->
 
-                    <ProductKey>
-                        <Key>33PXH-7Y6KF-2VJC9-XBBR8-HVTHH</Key>
+                    <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
+                    <ProductKey>MHF9N-XY6XB-WVXMC-BTDCT-MKKG7
                         <WillShowUI>Never</WillShowUI>
                     </ProductKey>
-
-                    Notice the addition of the `<Key>` element.
-                -->
-
-                <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
-                <ProductKey>MHF9N-XY6XB-WVXMC-BTDCT-MKKG7
-                    <WillShowUI>Never</WillShowUI>
-                </ProductKey>
-            </UserData>
-            <ImageInstall>
-                <OSImage>
-                    <InstallTo>
-                        <DiskID>0</DiskID>
-                        <PartitionID>1</PartitionID>
-                    </InstallTo>
-                    <WillShowUI>OnError</WillShowUI>
-                    <InstallToAvailablePartition>false</InstallToAvailablePartition>
-                    <InstallFrom>
-                        <MetaData wcm:action="add">
-                            <Key>/IMAGE/NAME</Key>
-                            <Value>Windows 8.1 Enterprise Evaluation</Value>
-                        </MetaData>
-                    </InstallFrom>
-                </OSImage>
-            </ImageInstall>
-        </component>
-        <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-            <SetupUILanguage>
+                </UserData>
+                <ImageInstall>
+                    <OSImage>
+                        <InstallTo>
+                            <DiskID>0</DiskID>
+                            <PartitionID>1</PartitionID>
+                        </InstallTo>
+                        <WillShowUI>OnError</WillShowUI>
+                        <InstallToAvailablePartition>false</InstallToAvailablePartition>
+                        <InstallFrom>
+                            <MetaData wcm:action="add">
+                                <Key>/IMAGE/NAME</Key>
+                                <Value>Windows 8.1 Enterprise Evaluation</Value>
+                            </MetaData>
+                        </InstallFrom>
+                    </OSImage>
+                </ImageInstall>
+            </component>
+            <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+                <SetupUILanguage>
+                    <UILanguage>en-US</UILanguage>
+                </SetupUILanguage>
+                <InputLocale>en-US</InputLocale>
+                <SystemLocale>en-US</SystemLocale>
                 <UILanguage>en-US</UILanguage>
-            </SetupUILanguage>
-            <InputLocale>en-US</InputLocale>
-            <SystemLocale>en-US</SystemLocale>
-            <UILanguage>en-US</UILanguage>
-            <UILanguageFallback>en-US</UILanguageFallback>
-            <UserLocale>en-US</UserLocale>
-        </component>
-    </settings>
-    <settings pass="offlineServicing">
-        <component name="Microsoft-Windows-LUA-Settings" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-            <EnableLUA>false</EnableLUA>
-        </component>
-    </settings>
-    <settings pass="oobeSystem">
-        <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-            <UserAccounts>
-                <AdministratorPassword>
-                    <Value>vagrant</Value>
-                    <PlainText>true</PlainText>
-                </AdministratorPassword>
-                <LocalAccounts>
-                    <LocalAccount wcm:action="add">
-                        <Password>
-                            <Value>vagrant</Value>
-                            <PlainText>true</PlainText>
-                        </Password>
-                        <Description>Vagrant User</Description>
-                        <DisplayName>vagrant</DisplayName>
-                        <Group>administrators</Group>
-                        <Name>vagrant</Name>
-                    </LocalAccount>
-                </LocalAccounts>
-            </UserAccounts>
-            <OOBE>
-                <HideEULAPage>true</HideEULAPage>
-                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
-                <NetworkLocation>Home</NetworkLocation>
-                <ProtectYourPC>1</ProtectYourPC>
-            </OOBE>
-            <AutoLogon>
-                <Password>
-                    <Value>vagrant</Value>
-                    <PlainText>true</PlainText>
-                </Password>
-                <Username>vagrant</Username>
-                <Enabled>true</Enabled>
-            </AutoLogon>
-            <FirstLogonCommands>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c powershell -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"</CommandLine>
-                    <Description>Set Execution Policy</Description>
-                    <Order>1</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>%SystemRoot%\System32\reg.exe ADD HKLM\SYSTEM\CurrentControlSet\Control\Power\ /v HibernateFileSizePercent /t REG_DWORD /d 0 /f</CommandLine>
-                    <Order>3</Order>
-                    <Description>Zero Hibernation File</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>%SystemRoot%\System32\reg.exe ADD HKLM\SYSTEM\CurrentControlSet\Control\Power\ /v HibernateEnabled /t REG_DWORD /d 0 /f</CommandLine>
-                    <Order>4</Order>
-                    <Description>Disable Hibernation Mode</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c wmic useraccount where "name='vagrant'" set PasswordExpires=FALSE</CommandLine>
-                    <Order>5</Order>
-                    <Description>Disable password expiration for vagrant user</Description>
-                </SynchronousCommand>
-                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\update-windows.ps1</CommandLine>
-                    <Description>Install Windows Updates</Description>
-                    <Order>6</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-            </FirstLogonCommands>
-            <ShowWindowsLive>false</ShowWindowsLive>
-        </component>
-    </settings>
-    <settings pass="specialize">
-        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-            <OEMInformation>
-                <HelpCustomized>false</HelpCustomized>
-            </OEMInformation>
-            <!-- Rename computer here. -->
-            <ComputerName>vagrant-81</ComputerName>
-            <TimeZone>Pacific Standard Time</TimeZone>
-            <RegisteredOwner/>
-        </component>
-        <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-            <SkipAutoActivation>true</SkipAutoActivation>
-        </component>
-    </settings>
-    <cpi:offlineImage xmlns:cpi="urn:schemas-microsoft-com:cpi" cpi:source="catalog:d:/sources/install_windows 7 ENTERPRISE.clg"/>
-</unattend>
+                <UILanguageFallback>en-US</UILanguageFallback>
+                <UserLocale>en-US</UserLocale>
+            </component>
+        </settings>
+        <settings pass="offlineServicing">
+            <component name="Microsoft-Windows-LUA-Settings" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+                <EnableLUA>false</EnableLUA>
+            </component>
+        </settings>
+        <settings pass="oobeSystem">
+            <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+                <UserAccounts>
+                    <AdministratorPassword>
+                        <Value>vagrant</Value>
+                        <PlainText>true</PlainText>
+                    </AdministratorPassword>
+                    <LocalAccounts>
+                        <LocalAccount wcm:action="add">
+                            <Password>
+                                <Value>vagrant</Value>
+                                <PlainText>true</PlainText>
+                            </Password>
+                            <Description>Vagrant User</Description>
+                            <DisplayName>vagrant</DisplayName>
+                            <Group>administrators</Group>
+                            <Name>vagrant</Name>
+                        </LocalAccount>
+                    </LocalAccounts>
+                </UserAccounts>
+                <OOBE>
+                    <HideEULAPage>true</HideEULAPage>
+                    <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                    <NetworkLocation>Home</NetworkLocation>
+                    <ProtectYourPC>1</ProtectYourPC>
+                </OOBE>
+                <AutoLogon>
+                    <Password>
+                        <Value>vagrant</Value>
+                        <PlainText>true</PlainText>
+                    </Password>
+                    <Username>vagrant</Username>
+                    <Enabled>true</Enabled>
+                </AutoLogon>
+                <FirstLogonCommands>
+                    <SynchronousCommand wcm:action="add">
+                        <CommandLine>powershell -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"</CommandLine>
+                        <Description>Set Execution Policy</Description>
+                        <Order>1</Order>
+                        <RequiresUserInput>true</RequiresUserInput>
+                    </SynchronousCommand>
+                    <SynchronousCommand wcm:action="add">
+                        <CommandLine>cmd.exe /c wmic useraccount where "name='vagrant'" set PasswordExpires=FALSE</CommandLine>
+                        <Order>2</Order>
+                        <Description>Disable password expiration for vagrant user</Description>
+                    </SynchronousCommand>
+                     <SynchronousCommand wcm:action="add">
+                        <CommandLine>powershell -NoLogo -ExecutionPolicy RemoteSigned -File a:\update-windows.ps1</CommandLine>
+                        <Description>Update Windows, and when finished, run configure-winrm.ps1 to turn WinRM on so this party can get started</Description>
+                        <Order>3</Order>
+                        <RequiresUserInput>true</RequiresUserInput>
+                    </SynchronousCommand>
+                </FirstLogonCommands>
+                <ShowWindowsLive>false</ShowWindowsLive>
+            </component>
+        </settings>
+        <settings pass="specialize">
+            <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+                <OEMInformation>
+                    <HelpCustomized>false</HelpCustomized>
+                </OEMInformation>
+                <!-- Rename computer here. -->
+                <ComputerName>vagrant-81</ComputerName>
+                <TimeZone>Pacific Standard Time</TimeZone>
+                <RegisteredOwner/>
+            </component>
+            <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+                <SkipAutoActivation>true</SkipAutoActivation>
+            </component>
+        </settings>
+        <cpi:offlineImage xmlns:cpi="urn:schemas-microsoft-com:cpi" cpi:source="catalog:d:/sources/install_windows 7 ENTERPRISE.clg"/>
+    </unattend>

--- a/configure-winrm.ps1
+++ b/configure-winrm.ps1
@@ -14,3 +14,5 @@ cmd.exe /c netsh firewall add portopening TCP 5985 "Port 5985"
 cmd.exe /c net stop winrm
 cmd.exe /c sc config winrm start= auto
 cmd.exe /c net start winrm
+
+exit 0

--- a/disable-hibernate.ps1
+++ b/disable-hibernate.ps1
@@ -1,0 +1,2 @@
+Set-ItemProperty HKLM:\SYSTEM\CurrentControlSet\Control\Power\ -name HiberFileSizePercent -value 0
+Set-ItemProperty HKLM:\SYSTEM\CurrentControlSet\Control\Power\ -name HibernateEnabled -value 0

--- a/enable-uac.ps1
+++ b/enable-uac.ps1
@@ -1,0 +1,1 @@
+Set-ItemProperty -Path HKLM:\Software\Microsoft\Windows\CurrentVersion\policies\system -Name EnableLUA -Value 1

--- a/install-7zip.ps1
+++ b/install-7zip.ps1
@@ -1,6 +1,0 @@
-$version = '920'
-$msi_file_name = "7z$version-x64.msi"
-$download_url = "http://www.7-zip.org/a/$msi_file_name"
-
-(New-Object System.Net.WebClient).DownloadFile($download_url, "C:\Windows\Temp\$msi_file_name")
-&msiexec /i "C:\Windows\Temp\$msi_file_name" INSTALLDIR='C:\7-zip' /qb

--- a/install-vmware-tools.ps1
+++ b/install-vmware-tools.ps1
@@ -1,6 +1,21 @@
-# from /Applications/VMware Fusion.app/Contents/Library/isoimages/windows.iso
+# Set the path of the VMWare Tools ISO - this is set in the Packer JSON file
 
-&"c:\7-zip\7z.exe" x "C:\Windows\Temp\windows.iso" -oc:\windows\temp\vmware -aoa | Out-Host
-&C:\Windows\Temp\vmware\setup64.exe /S /v`"/qn REBOOT=R`" | Out-Host
+$isopath = "C:\Windows\Temp\windows.iso"
 
-exit 0
+# Mount the .iso, then build the path to the installer by getting the Driveletter attribute from Get-DiskImage piped into Get-Volume and adding a :\setup64.exe
+# A separate variable is used for the parameters. There are cleaner ways of doing this. I chose the /qr MSI Installer flag because I personally hate silent installers
+# Even though our build is headless. 
+
+
+Mount-DiskImage -ImagePath $isopath
+$exe = ((Get-DiskImage -ImagePath $isopath | Get-Volume).Driveletter + ':\setup64.exe')
+$parameters = '/S /v "/qr REBOOT=R"'
+
+# Now we execute the process with Start-Process, which lets the script wait until the process is complete. 
+
+Start-Process $exe $parameters -Wait
+
+#Time to clean up - dismount the image and delete the original ISO
+
+Dismount-DiskImage -ImagePath $isopath
+Remove-Item $isopath

--- a/packer.json
+++ b/packer.json
@@ -10,9 +10,9 @@
     ],
     "guest_os_type": "windows8-64",
     "headless": true,
-    "iso_url": "/Users/Lucius/ISOs/OSes/Windows81ENT/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X64FREE_EN-US_DV9.ISO",
+    "iso_url": "/Users/Lucius/ISOs/OSes/Windows81ENT/Win81_ENT-Patched-8-1-2015.iso",
     "iso_checksum_type": "md5",
-    "iso_checksum": "ee63618e3be220d86b993c1abbcf32eb",
+    "iso_checksum": "12ac5c1c45d2ede64b380265c2cb070a",
     "winrm_username": "vagrant",
     "winrm_password": "vagrant",
     "winrm_timeout": "6h",
@@ -34,8 +34,9 @@
     "scripts": [
       "configure-private-network.ps1",
       "enable-rdp.ps1",
-      "install-7zip.ps1",
-      "install-vmware-tools.ps1"
+      "install-vmware-tools.ps1",
+      "enable-uac.ps1",
+      "disable-hibernate.ps1"
 ]
   }],
   "post-processors": [

--- a/update-windows.ps1
+++ b/update-windows.ps1
@@ -3,41 +3,6 @@ param($global:RestartRequired=0,
         $global:MaxCycles=5,
         $MaxUpdatesPerCycle=500)
 
-# Get the ID and security principal of the current user account
-$myWindowsID=[System.Security.Principal.WindowsIdentity]::GetCurrent()
-$myWindowsPrincipal=new-object System.Security.Principal.WindowsPrincipal($myWindowsID)
- 
-# Get the security principal for the Administrator role
-$adminRole=[System.Security.Principal.WindowsBuiltInRole]::Administrator
- 
-# Check to see if we are currently running "as Administrator"
-if ($myWindowsPrincipal.IsInRole($adminRole))
-   {
-   # We are running "as Administrator" - so change the title and background color to indicate this
-   $Host.UI.RawUI.WindowTitle = $myInvocation.MyCommand.Definition + "(Elevated)"
-   $Host.UI.RawUI.BackgroundColor = "DarkBlue"
-   clear-host
-   }
-else
-   {
-   # We are not running "as Administrator" - so relaunch as administrator
-   
-   # Create a new process object that starts PowerShell
-   $newProcess = new-object System.Diagnostics.ProcessStartInfo "PowerShell";
-   
-   # Specify the current script path and name as a parameter
-   $newProcess.Arguments = $myInvocation.MyCommand.Definition;
-   
-   # Indicate that the process should be elevated
-   $newProcess.Verb = "runas";
-   
-   # Start the new process
-   [System.Diagnostics.Process]::Start($newProcess);
-   
-   # Exit from the current, unelevated, process
-   exit
-   }
-
 $Logfile = "C:\Windows\Temp\win-updates.log"
 
 function LogWrite {


### PR DESCRIPTION
# Huge changes!

## Removed the requirement for 7Zip
Using native tools built into Windows 8.1, I was able to remove the requirement for 7Zip to install VMWare tools. Solves [this issue](https://github.com/luciusbono/Packer-Windows81/issues/3)

## Got Windows Updates working!
This was HUUUUGE. It turns out that the update scripts require UAC to be turned off to work. UAC is turned off in the `Autounattend.xml`, but it gets turned back on via a script. 

## Moved the hibernation settings out of Autounattend.xml and into a script
Per [this issue](https://github.com/luciusbono/Packer-Windows81/issues/2)

## Turned off UAC via a script
See [this issue](https://github.com/luciusbono/Packer-Windows81/issues/7)

## Cleaned up the Autounattend.xml / packer.json

Learned a lot more about how these files work. Cleaned them up as best as I can.
